### PR TITLE
Fix future post date

### DIFF
--- a/_posts/2025-07-23-first-devlog.md
+++ b/_posts/2025-07-23-first-devlog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Devlog #1 — Getting Started"
-date: 2025-07-25
+date: 2025-07-23
 ---
 
 I’ve started working on a GPS-based crafting game using Flutter.  


### PR DESCRIPTION
## Summary
- update devlog post date to July 23, 2025

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_688195c116c0832c9d38671b807a555e